### PR TITLE
fix tar archive reproducibility

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,9 +37,13 @@ in rec {
       buildCommand = ''
         storePaths=$(perl ${pathsFromGraph} ./closure-*)
 
+        # https://reproducible-builds.org/docs/archives
         tar -cf - \
           --owner=0 --group=0 --mode=u+rw,uga+r \
           --hard-dereference \
+          --mtime="@$SOURCE_DATE_EPOCH" \
+          --format=gnu \
+          --sort=name \
           $storePaths | bzip2 -z > $out
       '';
     };


### PR DESCRIPTION
In our project produce binary reproducible binaries, and we would like to build, release and sign bundled versions as well.

However currently the resulting files are not reproducible. After some investigation I've narrowed it down to non-deterministic `tar` invocation.

This PR changes it to something I've found online, and I verified that binaries between two machines produce byte-identical bundled binary.