### PR TITLE
flake: Use new nix bundle api

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,41 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,34 @@
 {
   description = "The purely functional package manager";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-  outputs = { self, nixpkgs }: let
-    systems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
-    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-  in {
-    bundlers = {
-      nix-bundle = { program, system }: let
-        nixpkgs' = nixpkgs.legacyPackages.${system};
-        nix-bundle = import self { nixpkgs = nixpkgs'; };
-        script = nixpkgs'.writeScript "startup" ''
-          #!/bin/sh
-          .${nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -- ${program} "$@"
-        '';
-      in nix-bundle.makebootstrap {
-        targets = [ script ];
-        startup = ".${builtins.unsafeDiscardStringContext script} '\"$@\"'";
-      };
-    };
-
-    defaultBundler = self.bundlers.nix-bundle;
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
   };
+
+  outputs =
+    inputs:
+    let
+      inherit (inputs.nixpkgs) lib;
+    in
+    inputs.utils.lib.eachDefaultSystem (system: {
+      bundlers = {
+        default = inputs.self.bundlers.${system}.nix-bundle;
+        nix-bundle =
+          drv:
+          let
+            program = lib.getExe drv;
+            nixpkgs = inputs.nixpkgs.legacyPackages.${system};
+            nix-bundle = import inputs.self { inherit nixpkgs; };
+            script = nixpkgs.writeScript "startup" ''
+              #!/bin/sh
+              .${nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -- ${program} "$@"
+            '';
+          in
+          nix-bundle.makebootstrap {
+            targets = [ script ];
+            startup = ".${builtins.unsafeDiscardStringContext script} '\"$@\"'";
+          };
+      };
+    });
 }


### PR DESCRIPTION
Nix now passes a derivation.

`nix bundle --bundler "github:nix-community/nix-bundle" ".#hello"`