### PR TITLE
document how `nix-bundle` can be used as a bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Or if you want to try graphical applications:
 ./nix-bundle.sh ivan /bin/ivan
 ```
 
+### Using the `nix bundle` command
+
+This command is provided by Nix, so that Nix ends up calling `nix-bundle` for you.
+It requires the `nix-command` and `flakes` experimental features to be enabled.
+
+We use `meta.mainProgram` attribute and other indicators to decide which executable to bundle.
+
+```sh
+nix bundle nixpkgs#hello --bundler github:nix-community/nix-bundle
+```
 
 ## Self-bundling (meta)
 


### PR DESCRIPTION
I think this type of usage should be documented as well.

(It would also be great if more functionality was exposed via the flake, either using other bundlers, or run commands, so people don't have to check out the repo. It would also help if the version in nixpkgs was more up-to-date: https://github.com/nix-community/nix-bundle/issues/116.)