### PR TITLE
Use closureInfo instead of pathsFromGraph

### DIFF
--- a/appdir.nix
+++ b/appdir.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, muslPkgs, perl, pathsFromGraph, fetchFromGitHub, coreutils, bash }:
+{ stdenv, lib, fetchurl, muslPkgs, perl, closureInfo, fetchFromGitHub, coreutils, bash }:
 
 let
   AppRun = targets: muslPkgs.stdenv.mkDerivation {
@@ -36,7 +36,7 @@ in
         exit 1
       fi
 
-      storePaths=$(${perl}/bin/perl ${pathsFromGraph} ./closure-*)
+      storePaths=$(${perl}/bin/perl ${closureInfo} ./closure-*)
 
       mkdir -p $out/${name}.AppDir
       cd $out/${name}.AppDir

--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,7 @@ rec {
       buildInputs = [ perl ];
       exportReferencesGraph = map (x: [("closure-" + baseNameOf x) x]) targets;
       buildCommand = ''
-        storePaths=$(perl ${pathsFromGraph} ./closure-*)
+        storePaths=$(perl ${closureInfo} ./closure-*)
 
         # https://reproducible-builds.org/docs/archives
         tar -cf - \


### PR DESCRIPTION
[This PR](https://github.com/NixOS/nixpkgs/pull/372931) recently removed `pathsFromGraph`. Switch to use `closureInfo` instead. 

Testing:
```
troy@battlestation ~/n/nix-bundle (fix-paths-from-graph)> nix bundle nixpkgs#hello
troy@battlestation ~/n/nix-bundle (fix-paths-from-graph)> ./hello-arx
Hello, world!
```